### PR TITLE
Separate elmish app into sub applications

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fantomas": {
-      "version": "6.2.3",
+      "version": "6.3.3",
       "commands": [
         "fantomas"
       ]

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ obj
 .paket
 paket-files
 turtles.db
+.DS_Store

--- a/paket.lock
+++ b/paket.lock
@@ -44,11 +44,11 @@ NUGET
       SkiaSharp (>= 2.88.7) - restriction: >= netstandard2.0
       SkiaSharp.NativeAssets.Linux (>= 2.88.7) - restriction: >= netstandard2.0
       SkiaSharp.NativeAssets.WebAssembly (>= 2.88.7) - restriction: >= netstandard2.0
-    Avalonia.Svg.Skia (11.0.0.17)
+    Avalonia.Svg.Skia (11.0.0.18)
       Avalonia (>= 11.0) - restriction: || (>= net461) (>= netstandard2.0)
       Avalonia.Skia (>= 11.0) - restriction: || (>= net461) (>= netstandard2.0)
       SkiaSharp (>= 2.88.6) - restriction: || (>= net461) (>= netstandard2.0)
-      Svg.Skia (>= 1.0.0.17) - restriction: || (>= net461) (>= netstandard2.0)
+      Svg.Skia (>= 1.0.0.18) - restriction: || (>= net461) (>= netstandard2.0)
     Avalonia.Themes.Fluent (11.0.10)
       Avalonia (>= 11.0.10) - restriction: >= netstandard2.0
     Avalonia.Win32 (11.0.10) - restriction: >= netstandard2.0
@@ -59,65 +59,65 @@ NUGET
       Avalonia (>= 11.0.10) - restriction: >= netstandard2.0
       Avalonia.FreeDesktop (>= 11.0.10) - restriction: >= netstandard2.0
       Avalonia.Skia (>= 11.0.10) - restriction: >= netstandard2.0
-    Dapper (2.1.35) - restriction: >= net6.0
-    Dapper.FSharp (4.7)
-      Dapper (>= 2.0.123) - restriction: >= net6.0
-      FSharp.Core (>= 6.0.7) - restriction: >= net6.0
+    Dapper (2.1.44) - restriction: >= net8.0
+    Dapper.FSharp (4.8)
+      Dapper (>= 2.1.35) - restriction: >= net8.0
+      FSharp.Core (>= 8.0.200) - restriction: >= net8.0
     Elmish (4.1) - restriction: >= net6.0
     ExCSS (4.2.5) - restriction: >= netstandard2.0
     FSharp.Core (8.0.200) - restriction: >= netstandard2.0
-    FSharp.SystemTextJson (1.2.42)
+    FSharp.SystemTextJson (1.3.13)
       FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
       System.Text.Json (>= 6.0) - restriction: >= netstandard2.0
     FsHttp (14.5)
       FSharp.Core (>= 5.0.2) - restriction: >= net6.0
-    HarfBuzzSharp (7.3.0.1) - restriction: || (>= net461) (>= netstandard2.0)
-      HarfBuzzSharp.NativeAssets.Android (>= 7.3.0.1) - restriction: || (&& (>= monoandroid) (< netstandard1.3)) (>= net6.0-android)
-      HarfBuzzSharp.NativeAssets.iOS (>= 7.3.0.1) - restriction: || (&& (< net6.0) (>= xamarinios)) (>= net6.0-ios)
-      HarfBuzzSharp.NativeAssets.macOS (>= 7.3.0.1) - restriction: || (&& (< monoandroid) (>= net6.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netstandard1.3) (< netstandard2.0) (< uap10.1) (< xamarintvos) (< xamarinwatchos)) (>= net462) (&& (< net6.0) (>= netcoreapp3.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net6.0) (>= xamarinmac)) (>= net6.0-macos) (&& (< netcoreapp3.1) (>= netstandard2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard2.0) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos))
-      HarfBuzzSharp.NativeAssets.tvOS (>= 7.3.0.1) - restriction: || (&& (< net6.0) (>= xamarintvos)) (>= net6.0-tvos)
-      HarfBuzzSharp.NativeAssets.watchOS (>= 7.3.0.1) - restriction: >= xamarinwatchos
-      HarfBuzzSharp.NativeAssets.Win32 (>= 7.3.0.1) - restriction: || (&& (< monoandroid) (>= net6.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netstandard1.3) (< netstandard2.0) (< uap10.1) (< xamarintvos) (< xamarinwatchos)) (>= net462) (&& (< net6.0) (>= netcoreapp3.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< netcoreapp3.1) (>= netstandard2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard2.0) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos))
+    HarfBuzzSharp (7.3.0.2) - restriction: || (>= net461) (>= netstandard2.0)
+      HarfBuzzSharp.NativeAssets.Android (>= 7.3.0.2) - restriction: || (&& (>= monoandroid) (< netstandard1.3)) (>= net6.0-android)
+      HarfBuzzSharp.NativeAssets.iOS (>= 7.3.0.2) - restriction: || (&& (< net6.0) (>= xamarinios)) (>= net6.0-ios)
+      HarfBuzzSharp.NativeAssets.macOS (>= 7.3.0.2) - restriction: || (&& (< monoandroid) (>= net6.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netstandard1.3) (< netstandard2.0) (< uap10.1) (< xamarintvos) (< xamarinwatchos)) (>= net462) (&& (< net6.0) (>= netcoreapp3.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net6.0) (>= xamarinmac)) (>= net6.0-macos) (&& (< netcoreapp3.1) (>= netstandard2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard2.0) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos))
+      HarfBuzzSharp.NativeAssets.tvOS (>= 7.3.0.2) - restriction: || (&& (< net6.0) (>= xamarintvos)) (>= net6.0-tvos)
+      HarfBuzzSharp.NativeAssets.watchOS (>= 7.3.0.2) - restriction: >= xamarinwatchos
+      HarfBuzzSharp.NativeAssets.Win32 (>= 7.3.0.2) - restriction: || (&& (< monoandroid) (>= net6.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netstandard1.3) (< netstandard2.0) (< uap10.1) (< xamarintvos) (< xamarinwatchos)) (>= net462) (&& (< net6.0) (>= netcoreapp3.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< netcoreapp3.1) (>= netstandard2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard2.0) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos))
       System.Memory (>= 4.5.5) - restriction: || (&& (< monoandroid) (>= netstandard1.3) (< netstandard2.0) (< xamarintvos) (< xamarinwatchos)) (>= net462) (&& (>= netstandard2.0) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos)) (>= tizen4.0) (>= uap10.1)
-    HarfBuzzSharp.NativeAssets.Android (7.3.0.1) - restriction: || (&& (>= monoandroid) (< netstandard1.3) (>= netstandard2.0)) (>= net6.0-android)
-    HarfBuzzSharp.NativeAssets.iOS (7.3.0.1) - restriction: || (&& (< net6.0) (>= xamarinios)) (>= net6.0-ios)
-    HarfBuzzSharp.NativeAssets.Linux (7.3.0.1) - restriction: >= netstandard2.0
-      HarfBuzzSharp (>= 7.3.0.1) - restriction: >= netstandard1.3
-    HarfBuzzSharp.NativeAssets.macOS (7.3.0.1) - restriction: || (&& (< monoandroid) (>= net6.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= net462) (>= netstandard2.0)) (&& (< net6.0) (>= netcoreapp3.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net6.0) (>= xamarinmac)) (>= net6.0-macos) (&& (< netcoreapp3.1) (>= netstandard2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard2.0) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos))
-    HarfBuzzSharp.NativeAssets.tvOS (7.3.0.1) - restriction: || (&& (< net6.0) (>= netstandard2.0) (>= xamarintvos)) (>= net6.0-tvos)
-    HarfBuzzSharp.NativeAssets.watchOS (7.3.0.1) - restriction: && (>= netstandard2.0) (>= xamarinwatchos)
-    HarfBuzzSharp.NativeAssets.WebAssembly (7.3.0.1) - restriction: >= netstandard2.0
-    HarfBuzzSharp.NativeAssets.Win32 (7.3.0.1) - restriction: || (&& (< monoandroid) (>= net6.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= net462) (>= netstandard2.0)) (&& (< net6.0) (>= netcoreapp3.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< netcoreapp3.1) (>= netstandard2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard2.0) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos))
+    HarfBuzzSharp.NativeAssets.Android (7.3.0.2) - restriction: || (&& (>= monoandroid) (< netstandard1.3) (>= netstandard2.0)) (>= net6.0-android)
+    HarfBuzzSharp.NativeAssets.iOS (7.3.0.2) - restriction: || (&& (< net6.0) (>= xamarinios)) (>= net6.0-ios)
+    HarfBuzzSharp.NativeAssets.Linux (7.3.0.2) - restriction: >= netstandard2.0
+      HarfBuzzSharp (>= 7.3.0.2) - restriction: >= netstandard1.3
+    HarfBuzzSharp.NativeAssets.macOS (7.3.0.2) - restriction: || (&& (< monoandroid) (>= net6.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= net462) (>= netstandard2.0)) (&& (< net6.0) (>= netcoreapp3.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net6.0) (>= xamarinmac)) (>= net6.0-macos) (&& (< netcoreapp3.1) (>= netstandard2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard2.0) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos))
+    HarfBuzzSharp.NativeAssets.tvOS (7.3.0.2) - restriction: || (&& (< net6.0) (>= netstandard2.0) (>= xamarintvos)) (>= net6.0-tvos)
+    HarfBuzzSharp.NativeAssets.watchOS (7.3.0.2) - restriction: && (>= netstandard2.0) (>= xamarinwatchos)
+    HarfBuzzSharp.NativeAssets.WebAssembly (7.3.0.2) - restriction: >= netstandard2.0
+    HarfBuzzSharp.NativeAssets.Win32 (7.3.0.2) - restriction: || (&& (< monoandroid) (>= net6.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= net462) (>= netstandard2.0)) (&& (< net6.0) (>= netcoreapp3.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< netcoreapp3.1) (>= netstandard2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard2.0) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos))
     MicroCom.Runtime (0.11) - restriction: >= netstandard2.0
     Microsoft.Bcl.AsyncInterfaces (8.0) - restriction: || (&& (>= net462) (>= netstandard2.0)) (&& (< net6.0) (>= netstandard2.0))
       System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: || (>= net462) (&& (>= netstandard2.0) (< netstandard2.1))
-    Microsoft.Data.Sqlite (8.0.3)
-      Microsoft.Data.Sqlite.Core (>= 8.0.3) - restriction: >= netstandard2.0
+    Microsoft.Data.Sqlite (8.0.4)
+      Microsoft.Data.Sqlite.Core (>= 8.0.4) - restriction: >= netstandard2.0
       SQLitePCLRaw.bundle_e_sqlite3 (>= 2.1.6) - restriction: >= netstandard2.0
-    Microsoft.Data.Sqlite.Core (8.0.3) - restriction: >= netstandard2.0
+    Microsoft.Data.Sqlite.Core (8.0.4) - restriction: >= netstandard2.0
       SQLitePCLRaw.core (>= 2.1.6) - restriction: >= netstandard2.0
-    ShimSkiaSharp (1.0.0.17) - restriction: || (>= net461) (>= netstandard2.0)
-    SkiaSharp (2.88.7) - restriction: || (>= net461) (>= netstandard2.0)
-      SkiaSharp.NativeAssets.Android (>= 2.88.7) - restriction: || (&& (>= monoandroid) (< netstandard1.3)) (>= net6.0-android)
-      SkiaSharp.NativeAssets.iOS (>= 2.88.7) - restriction: || (&& (< net6.0) (>= xamarinios)) (>= net6.0-ios)
-      SkiaSharp.NativeAssets.macOS (>= 2.88.7) - restriction: || (&& (< monoandroid) (>= net6.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netstandard1.3) (< netstandard2.0) (< uap10.1) (< xamarintvos) (< xamarinwatchos)) (>= net462) (&& (< net6.0) (>= netcoreapp3.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net6.0) (>= xamarinmac)) (>= net6.0-macos) (&& (< netcoreapp3.1) (>= netstandard2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard2.0) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos))
-      SkiaSharp.NativeAssets.tvOS (>= 2.88.7) - restriction: || (&& (< net6.0) (>= xamarintvos)) (>= net6.0-tvos)
-      SkiaSharp.NativeAssets.watchOS (>= 2.88.7) - restriction: >= xamarinwatchos
-      SkiaSharp.NativeAssets.Win32 (>= 2.88.7) - restriction: || (&& (< monoandroid) (>= net6.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netstandard1.3) (< netstandard2.0) (< uap10.1) (< xamarintvos) (< xamarinwatchos)) (>= net462) (&& (< net6.0) (>= netcoreapp3.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< netcoreapp3.1) (>= netstandard2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard2.0) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos))
+    ShimSkiaSharp (1.0.0.18) - restriction: || (>= net461) (>= netstandard2.0)
+    SkiaSharp (2.88.8) - restriction: || (>= net461) (>= netstandard2.0)
+      SkiaSharp.NativeAssets.Android (>= 2.88.8) - restriction: || (&& (>= monoandroid) (< netstandard1.3)) (>= net6.0-android)
+      SkiaSharp.NativeAssets.iOS (>= 2.88.8) - restriction: || (&& (< net6.0) (>= xamarinios)) (>= net6.0-ios)
+      SkiaSharp.NativeAssets.macOS (>= 2.88.8) - restriction: || (&& (< monoandroid) (>= net6.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netstandard1.3) (< netstandard2.0) (< uap10.1) (< xamarintvos) (< xamarinwatchos)) (>= net462) (&& (< net6.0) (>= netcoreapp3.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net6.0) (>= xamarinmac)) (>= net6.0-macos) (&& (< netcoreapp3.1) (>= netstandard2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard2.0) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos))
+      SkiaSharp.NativeAssets.tvOS (>= 2.88.8) - restriction: || (&& (< net6.0) (>= xamarintvos)) (>= net6.0-tvos)
+      SkiaSharp.NativeAssets.watchOS (>= 2.88.8) - restriction: >= xamarinwatchos
+      SkiaSharp.NativeAssets.Win32 (>= 2.88.8) - restriction: || (&& (< monoandroid) (>= net6.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netstandard1.3) (< netstandard2.0) (< uap10.1) (< xamarintvos) (< xamarinwatchos)) (>= net462) (&& (< net6.0) (>= netcoreapp3.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< netcoreapp3.1) (>= netstandard2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard2.0) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos))
       System.IO.UnmanagedMemoryStream (>= 4.3) - restriction: && (< monoandroid) (< net462) (>= netstandard1.3) (< netstandard2.0) (< uap10.1) (< xamarintvos) (< xamarinwatchos)
       System.Memory (>= 4.5.5) - restriction: || (&& (< monoandroid) (>= netstandard1.3) (< netstandard2.0) (< xamarintvos) (< xamarinwatchos)) (>= net462) (&& (>= netstandard2.0) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos)) (>= tizen4.0) (>= uap10.1)
-    SkiaSharp.HarfBuzz (2.88.7) - restriction: || (>= net461) (>= netstandard2.0)
-      HarfBuzzSharp (>= 7.3.0.1) - restriction: >= netstandard1.3
-      SkiaSharp (>= 2.88.7) - restriction: >= netstandard1.3
-    SkiaSharp.NativeAssets.Android (2.88.7) - restriction: || (&& (>= monoandroid) (>= net461) (< netstandard1.3)) (&& (>= monoandroid) (< netstandard1.3) (>= netstandard2.0)) (>= net6.0-android)
-    SkiaSharp.NativeAssets.iOS (2.88.7) - restriction: || (&& (>= net461) (>= xamarinios)) (&& (< net6.0) (>= xamarinios)) (>= net6.0-ios)
-    SkiaSharp.NativeAssets.Linux (2.88.7) - restriction: >= netstandard2.0
-      SkiaSharp (>= 2.88.7) - restriction: >= netstandard1.3
-    SkiaSharp.NativeAssets.macOS (2.88.7) - restriction: || (&& (< monoandroid) (>= net6.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= net461) (>= net6.0)) (&& (>= net461) (>= netcoreapp3.1)) (&& (>= net461) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (&& (>= net461) (>= netstandard2.1)) (&& (>= net461) (>= xamarinmac)) (>= net462) (&& (< net6.0) (>= netcoreapp3.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net6.0) (>= xamarinmac)) (>= net6.0-macos) (&& (< netcoreapp3.1) (>= netstandard2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard2.0) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos))
-    SkiaSharp.NativeAssets.tvOS (2.88.7) - restriction: || (&& (>= net461) (>= xamarintvos)) (&& (< net6.0) (>= netstandard2.0) (>= xamarintvos)) (>= net6.0-tvos)
-    SkiaSharp.NativeAssets.watchOS (2.88.7) - restriction: || (&& (>= net461) (>= xamarinwatchos)) (&& (>= netstandard2.0) (>= xamarinwatchos))
-    SkiaSharp.NativeAssets.WebAssembly (2.88.7) - restriction: >= netstandard2.0
-    SkiaSharp.NativeAssets.Win32 (2.88.7) - restriction: || (&& (< monoandroid) (>= net6.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= net461) (>= net6.0)) (&& (>= net461) (>= netcoreapp3.1)) (&& (>= net461) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (&& (>= net461) (>= netstandard2.1)) (>= net462) (&& (< net6.0) (>= netcoreapp3.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< netcoreapp3.1) (>= netstandard2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard2.0) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos))
+    SkiaSharp.HarfBuzz (2.88.8) - restriction: || (>= net461) (>= netstandard2.0)
+      HarfBuzzSharp (>= 7.3.0.2) - restriction: >= netstandard1.3
+      SkiaSharp (>= 2.88.8) - restriction: >= netstandard1.3
+    SkiaSharp.NativeAssets.Android (2.88.8) - restriction: || (&& (>= monoandroid) (>= net461) (< netstandard1.3)) (&& (>= monoandroid) (< netstandard1.3) (>= netstandard2.0)) (>= net6.0-android)
+    SkiaSharp.NativeAssets.iOS (2.88.8) - restriction: || (&& (>= net461) (>= xamarinios)) (&& (< net6.0) (>= xamarinios)) (>= net6.0-ios)
+    SkiaSharp.NativeAssets.Linux (2.88.8) - restriction: >= netstandard2.0
+      SkiaSharp (>= 2.88.8) - restriction: >= netstandard1.3
+    SkiaSharp.NativeAssets.macOS (2.88.8) - restriction: || (&& (< monoandroid) (>= net6.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= net461) (>= net6.0)) (&& (>= net461) (>= netcoreapp3.1)) (&& (>= net461) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (&& (>= net461) (>= netstandard2.1)) (&& (>= net461) (>= xamarinmac)) (>= net462) (&& (< net6.0) (>= netcoreapp3.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net6.0) (>= xamarinmac)) (>= net6.0-macos) (&& (< netcoreapp3.1) (>= netstandard2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard2.0) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos))
+    SkiaSharp.NativeAssets.tvOS (2.88.8) - restriction: || (&& (>= net461) (>= xamarintvos)) (&& (< net6.0) (>= netstandard2.0) (>= xamarintvos)) (>= net6.0-tvos)
+    SkiaSharp.NativeAssets.watchOS (2.88.8) - restriction: || (&& (>= net461) (>= xamarinwatchos)) (&& (>= netstandard2.0) (>= xamarinwatchos))
+    SkiaSharp.NativeAssets.WebAssembly (2.88.8) - restriction: >= netstandard2.0
+    SkiaSharp.NativeAssets.Win32 (2.88.8) - restriction: || (&& (< monoandroid) (>= net6.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= net461) (>= net6.0)) (&& (>= net461) (>= netcoreapp3.1)) (&& (>= net461) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (&& (>= net461) (>= netstandard2.1)) (>= net462) (&& (< net6.0) (>= netcoreapp3.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< netcoreapp3.1) (>= netstandard2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard2.0) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos))
     SQLitePCLRaw.bundle_e_sqlite3 (2.1.8) - restriction: >= netstandard2.0
       SQLitePCLRaw.lib.e_sqlite3 (>= 2.1.8) - restriction: || (&& (< monoandroid9.0) (< net6.0-tvos) (>= netstandard2.0) (< xamarinios)) (>= net461) (>= net6.0-ios)
       SQLitePCLRaw.lib.e_sqlite3.android (>= 2.1.8) - restriction: >= monoandroid9.0
@@ -141,17 +141,17 @@ NUGET
       SQLitePCLRaw.core (>= 2.1.8) - restriction: >= netstandard2.0
     SQLitePCLRaw.provider.internal (2.1.8) - restriction: || (>= net6.0-tvos) (>= xamarinios)
       SQLitePCLRaw.core (>= 2.1.8) - restriction: >= netstandard2.0
-    Svg.Custom (1.0.0.17) - restriction: || (>= net461) (>= netstandard2.0)
+    Svg.Custom (1.0.0.18) - restriction: || (>= net461) (>= netstandard2.0)
       ExCSS (>= 4.2.3) - restriction: >= netstandard2.0
       System.Memory (>= 4.5.5) - restriction: && (< net6.0) (>= netstandard2.0)
-    Svg.Model (1.0.0.17) - restriction: || (>= net461) (>= netstandard2.0)
-      ShimSkiaSharp (>= 1.0.0.17) - restriction: || (>= net461) (>= netstandard2.0)
-      Svg.Custom (>= 1.0.0.17) - restriction: || (>= net461) (>= netstandard2.0)
-    Svg.Skia (1.0.0.17) - restriction: || (>= net461) (>= netstandard2.0)
+    Svg.Model (1.0.0.18) - restriction: || (>= net461) (>= netstandard2.0)
+      ShimSkiaSharp (>= 1.0.0.18) - restriction: || (>= net461) (>= netstandard2.0)
+      Svg.Custom (>= 1.0.0.18) - restriction: || (>= net461) (>= netstandard2.0)
+    Svg.Skia (1.0.0.18) - restriction: || (>= net461) (>= netstandard2.0)
       SkiaSharp (>= 2.88.6) - restriction: || (>= net461) (>= netstandard2.0)
       SkiaSharp.HarfBuzz (>= 2.88.6) - restriction: || (>= net461) (>= netstandard2.0)
-      Svg.Custom (>= 1.0.0.17) - restriction: || (>= net461) (>= netstandard2.0)
-      Svg.Model (>= 1.0.0.17) - restriction: || (>= net461) (>= netstandard2.0)
+      Svg.Custom (>= 1.0.0.18) - restriction: || (>= net461) (>= netstandard2.0)
+      Svg.Model (>= 1.0.0.18) - restriction: || (>= net461) (>= netstandard2.0)
     System.Buffers (4.5.1) - restriction: || (&& (>= monoandroid) (< netstandard1.1) (>= netstandard2.0)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard2.0) (< win8)) (&& (>= monotouch) (>= net461)) (&& (>= monotouch) (>= netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos)) (&& (>= net461) (< netstandard1.1)) (&& (>= net461) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (&& (>= net461) (>= tizen4.0)) (&& (>= net461) (>= uap10.1)) (&& (>= net461) (>= xamarinios)) (&& (>= net461) (>= xamarinmac)) (>= net462) (&& (< net6.0) (>= netstandard2.0)) (&& (< netstandard1.1) (>= netstandard2.0) (>= win8)) (&& (>= netstandard2.0) (>= tizen4.0)) (&& (>= netstandard2.0) (>= uap10.1)) (&& (< netstandard2.1) (>= xamarinios)) (&& (< netstandard2.1) (>= xamarinmac)) (&& (>= tizen4.0) (>= xamarinios)) (&& (>= tizen4.0) (>= xamarinmac)) (&& (>= uap10.1) (>= xamarinios)) (&& (>= uap10.1) (>= xamarinmac))
     System.ComponentModel.Annotations (5.0) - restriction: >= netstandard2.0
     System.IO.FileSystem.Primitives (4.3) - restriction: && (>= net461) (< net462) (< netstandard2.0)

--- a/src/App.fs
+++ b/src/App.fs
@@ -2,174 +2,80 @@ module App
 
 open System
 open System.Data
+open Elmish
+open Avalonia.FuncUI
+open Avalonia.FuncUI.Types
 open Avalonia.FuncUI.DSL
 open Avalonia.Controls
 open Avalonia.Layout
 open Avalonia.Media.Imaging
 open Avalonia.Platform
 open Avalonia.Svg.Skia
-open Elmish
 open ElmishUtility
 
 open Wanikani
 open MetaType
 
+type View =
+    | Login
+    | UserOverview
+
 type Msg =
     | DbInitialized
-    | UseToken of string option
-    | TokenInputChanged of string
-    | SaveToken
-    | FetchUserAttempt of AsyncOp<Object<User>>
+    | LoginMsg of Login.Msg
+    | UserOverviewMsg of UserOverview.Msg
 
 type State =
-    { token: string option
-      tokenInput: string option
-      user: AsyncOp<Object<User>> }
+    { currentView: View
+      login: Login.State
+      user: UserOverview.State option }
 
 let conn = Database.connection ()
 
 let init () =
-    { token = None
-      tokenInput = None
-      user = NotStarted },
-    Cmd.OfAsync.perform Database.createIfNotExist conn (fun _ -> DbInitialized)
+    let loginState, loginCmd = Login.init ()
+
+    let initialState =
+        { currentView = Login
+          login = loginState
+          user = None }
+
+    let initialCmd =
+        Cmd.batch
+            [ Cmd.OfAsync.perform Database.createIfNotExist conn (fun _ -> DbInitialized)
+              Cmd.map LoginMsg loginCmd ]
+
+    initialState, initialCmd
 
 let update (msg: Msg) (state: State) : State * Cmd<Msg> =
     match msg with
-    | DbInitialized -> state, Cmd.OfAsync.perform AccessToken.tryGet conn UseToken
-    | TokenInputChanged input -> { state with tokenInput = Some input }, Cmd.none
-    | UseToken(Some token) ->
-        { state with
-            token = Some token
-            tokenInput = None
-            user = InProgress },
-        Cmd.OfAsync.either User.request token (Finished >> FetchUserAttempt) (Error >> FetchUserAttempt)
-    | UseToken None ->
-        Cmd.OfAsync.start (AccessToken.delete conn)
+    | DbInitialized -> state, Cmd.none
+    | LoginMsg(Login.LoggedIn(token, user)) ->
+        let userState, userCmd = UserOverview.init token user
 
         { state with
-            token = None
-            tokenInput = None
-            user = NotStarted },
+            login = Login.init () |> fst
+            user = Some userState
+            currentView = UserOverview },
+        Cmd.map UserOverviewMsg userCmd
+    | LoginMsg loginMsg ->
+        let loginState, loginCmd = Login.update loginMsg state.login
+
+        { state with login = loginState }, Cmd.map LoginMsg loginCmd
+    | UserOverviewMsg UserOverview.Logout ->
+        { state with
+            user = None
+            currentView = Login },
         Cmd.none
-    | SaveToken ->
-        match state.tokenInput with
-        | Some input ->
-            { state with tokenInput = None },
-            Cmd.OfAsync.perform (AccessToken.save conn) input (fun _ -> UseToken state.tokenInput)
-        | None -> state, Cmd.none
-    | FetchUserAttempt(Error e) ->
-        Cmd.OfAsync.start (AccessToken.delete conn)
+    | UserOverviewMsg userMsg ->
+        let userOverviewState, userOverviewCmd =
+            UserOverview.update userMsg state.user.Value
 
         { state with
-            user = Error e
-            token = None },
-        Cmd.none
-    | FetchUserAttempt user -> { state with user = user }, Cmd.none
+            user = Some userOverviewState },
+        Cmd.map UserOverviewMsg userOverviewCmd
 
-[<RequireQualifiedAccess>]
-module Icons =
-    let user =
-        lazy new SvgImage(Source = SvgSource.Load("avares://Wanigraphy/Assets/Icons/turtle.svg", null))
-
-let view (state: State) (dispatch) =
-    DockPanel.create
-        [ DockPanel.children (
-              match state.user, state.token with
-              | Finished user, Some token ->
-                  [ StackPanel.create
-                        [ StackPanel.orientation Orientation.Horizontal
-                          StackPanel.horizontalAlignment HorizontalAlignment.Right
-                          StackPanel.dock Dock.Top
-                          StackPanel.margin 10
-                          StackPanel.children
-                              [ Button.create
-                                    [ Button.content (
-                                          StackPanel.create
-                                              [ StackPanel.orientation Orientation.Horizontal
-                                                StackPanel.spacing 10
-                                                StackPanel.children
-                                                    [ TextBlock.create
-                                                          [ TextBlock.text user.data.username
-                                                            TextBlock.verticalAlignment VerticalAlignment.Center
-                                                            TextBlock.fontSize 16 ]
-
-                                                      Image.create
-                                                          [ Image.source Icons.user.Value
-                                                            Image.height 25
-                                                            Image.width 25 ] ] ]
-                                      )
-                                      Button.flyout (
-                                          MenuFlyout.create
-                                              [ MenuFlyout.placement PlacementMode.BottomEdgeAlignedRight
-                                                MenuFlyout.showMode FlyoutShowMode.TransientWithDismissOnPointerMoveAway
-                                                MenuFlyout.viewItems
-                                                    [ MenuItem.create
-                                                          [ MenuItem.header "Logout"
-                                                            MenuItem.onClick (fun _ -> dispatch (UseToken None)) ] ] ]
-                                      ) ] ] ]
-                    StackPanel.create
-                        [ StackPanel.orientation Orientation.Horizontal
-                          StackPanel.horizontalAlignment HorizontalAlignment.Center
-                          StackPanel.verticalAlignment VerticalAlignment.Center
-                          StackPanel.spacing 10
-                          StackPanel.children
-                              [ TextBlock.create
-                                    [ TextBlock.fontSize 48
-                                      TextBlock.verticalAlignment VerticalAlignment.Center
-                                      TextBlock.text $"Welcome {user.data.username}" ] ] ] ]
-
-              | Finished user, None ->
-                  [ TextBlock.create
-                        [ TextBlock.text "Unexpected error"
-                          TextBlock.verticalAlignment VerticalAlignment.Center ] ]
-
-              | InProgress, _
-              | NotStarted, Some _ ->
-                  [ TextBlock.create
-                        [ TextBlock.text "Loading"
-                          TextBlock.horizontalAlignment HorizontalAlignment.Center
-                          TextBlock.verticalAlignment VerticalAlignment.Center ] ]
-
-              | NotStarted, None ->
-                  [ StackPanel.create
-                        [ StackPanel.orientation Orientation.Horizontal
-                          StackPanel.horizontalAlignment HorizontalAlignment.Center
-                          StackPanel.verticalAlignment VerticalAlignment.Center
-                          StackPanel.spacing 10
-                          StackPanel.children
-                              [ TextBox.create
-                                    [ TextBox.passwordChar '*'
-                                      TextBox.width 400
-                                      TextBox.verticalAlignment VerticalAlignment.Top
-                                      TextBox.onTextChanged (fun input ->
-                                          if String.IsNullOrWhiteSpace input |> not then
-                                              TokenInputChanged input |> dispatch) ]
-                                Button.create
-                                    [ Button.onClick (fun _ -> dispatch SaveToken)
-                                      Button.isEnabled (Option.isSome state.tokenInput)
-                                      Button.verticalAlignment VerticalAlignment.Top
-                                      Button.content "Login" ] ] ] ]
-
-              | Error ex, _ ->
-                  [ StackPanel.create
-                        [ StackPanel.orientation Orientation.Horizontal
-                          StackPanel.horizontalAlignment HorizontalAlignment.Center
-                          StackPanel.verticalAlignment VerticalAlignment.Center
-                          StackPanel.spacing 10
-                          StackPanel.height 60
-                          StackPanel.children
-                              [ TextBox.create
-                                    [ TextBox.passwordChar '*'
-                                      TextBox.width 400
-                                      TextBox.errors [ "Invalid token" ]
-                                      TextBox.verticalAlignment VerticalAlignment.Top
-                                      TextBox.onTextChanged (fun input ->
-                                          if String.IsNullOrWhiteSpace input |> not then
-                                              TokenInputChanged input |> dispatch) ]
-                                Button.create
-                                    [ Button.onClick (fun _ -> dispatch SaveToken)
-                                      Button.isEnabled (Option.isSome state.tokenInput)
-                                      Button.verticalAlignment VerticalAlignment.Top
-                                      Button.content "Login" ] ] ] ]
-          ) ]
+let view (state: State) (dispatch: Msg -> unit) =
+    match state.currentView with
+    | Login -> Login.view state.login (LoginMsg >> dispatch)
+    | UserOverview -> UserOverview.view state.user.Value (UserOverviewMsg >> dispatch)

--- a/src/App.fs
+++ b/src/App.fs
@@ -81,23 +81,23 @@ let view (state: State) (dispatch) =
                         [ StackPanel.orientation Orientation.Horizontal
                           StackPanel.horizontalAlignment HorizontalAlignment.Right
                           StackPanel.dock Dock.Top
-                          StackPanel.margin 10.0
+                          StackPanel.margin 10
                           StackPanel.children
                               [ Button.create
                                     [ Button.content (
                                           StackPanel.create
                                               [ StackPanel.orientation Orientation.Horizontal
-                                                StackPanel.spacing 10.0
+                                                StackPanel.spacing 10
                                                 StackPanel.children
                                                     [ TextBlock.create
                                                           [ TextBlock.text user.data.username
                                                             TextBlock.verticalAlignment VerticalAlignment.Center
-                                                            TextBlock.fontSize 16.0 ]
+                                                            TextBlock.fontSize 16 ]
 
                                                       Image.create
                                                           [ Image.source Icons.user.Value
-                                                            Image.height 25.0
-                                                            Image.width 25.0 ] ] ]
+                                                            Image.height 25
+                                                            Image.width 25 ] ] ]
                                       )
                                       Button.flyout (
                                           MenuFlyout.create
@@ -112,10 +112,10 @@ let view (state: State) (dispatch) =
                         [ StackPanel.orientation Orientation.Horizontal
                           StackPanel.horizontalAlignment HorizontalAlignment.Center
                           StackPanel.verticalAlignment VerticalAlignment.Center
-                          StackPanel.spacing 10.0
+                          StackPanel.spacing 10
                           StackPanel.children
                               [ TextBlock.create
-                                    [ TextBlock.fontSize 48.0
+                                    [ TextBlock.fontSize 48
                                       TextBlock.verticalAlignment VerticalAlignment.Center
                                       TextBlock.text $"Welcome {user.data.username}" ] ] ] ]
 
@@ -136,11 +136,11 @@ let view (state: State) (dispatch) =
                         [ StackPanel.orientation Orientation.Horizontal
                           StackPanel.horizontalAlignment HorizontalAlignment.Center
                           StackPanel.verticalAlignment VerticalAlignment.Center
-                          StackPanel.spacing 10.0
+                          StackPanel.spacing 10
                           StackPanel.children
                               [ TextBox.create
                                     [ TextBox.passwordChar '*'
-                                      TextBox.width 400.0
+                                      TextBox.width 400
                                       TextBox.verticalAlignment VerticalAlignment.Top
                                       TextBox.onTextChanged (fun input ->
                                           if String.IsNullOrWhiteSpace input |> not then
@@ -156,12 +156,12 @@ let view (state: State) (dispatch) =
                         [ StackPanel.orientation Orientation.Horizontal
                           StackPanel.horizontalAlignment HorizontalAlignment.Center
                           StackPanel.verticalAlignment VerticalAlignment.Center
-                          StackPanel.spacing 10.0
-                          StackPanel.height 60.0
+                          StackPanel.spacing 10
+                          StackPanel.height 60
                           StackPanel.children
                               [ TextBox.create
                                     [ TextBox.passwordChar '*'
-                                      TextBox.width 400.0
+                                      TextBox.width 400
                                       TextBox.errors [ "Invalid token" ]
                                       TextBox.verticalAlignment VerticalAlignment.Top
                                       TextBox.onTextChanged (fun input ->

--- a/src/App.fs
+++ b/src/App.fs
@@ -30,7 +30,7 @@ type State =
       login: Login.State
       user: UserOverview.State option }
 
-let conn = Database.connection ()
+let conn = Database.connection
 
 let init () =
     let loginState, loginCmd = Login.init ()

--- a/src/Database.fs
+++ b/src/Database.fs
@@ -74,7 +74,7 @@ Dapper.SqlMapper.AddTypeHandler(typeof<Uri>, UriHandler())
 // Map database nulls with Options
 Dapper.FSharp.SQLite.OptionTypes.register ()
 
-let connection () =
+let connection =
     let conn = new SqliteConnection("Data Source=turtles.db")
     conn.Open()
     conn

--- a/src/Login.fs
+++ b/src/Login.fs
@@ -101,23 +101,28 @@ let inputTokenView (state: State) (dispatch: Msg -> unit) (hasErrors: bool) : IV
                       Button.content "Login" ] ] ]
 
 let view (state: State) (dispatch: Msg -> unit) =
-    DockPanel.create
-        [ DockPanel.children (
-              match state.userFetchAttempt, state.token with
-              | Finished user, Some token -> []
+    Grid.create
+        [ Grid.children
+              [ StackPanel.create
+                    [ StackPanel.children
+                          [ DockPanel.create
+                                [ DockPanel.background Color.background
+                                  DockPanel.children (
+                                      match state.userFetchAttempt, state.token with
+                                      | Finished user, Some token -> []
 
-              | Finished user, None ->
-                  [ TextBlock.create
-                        [ TextBlock.text "Unexpected error"
-                          TextBlock.verticalAlignment VerticalAlignment.Center ] ]
+                                      | Finished user, None ->
+                                          [ TextBlock.create
+                                                [ TextBlock.text "Unexpected error"
+                                                  TextBlock.verticalAlignment VerticalAlignment.Center ] ]
 
-              | InProgress, _
-              | NotStarted, Some _ ->
-                  [ TextBlock.create
-                        [ TextBlock.text "Loading"
-                          TextBlock.horizontalAlignment HorizontalAlignment.Center
-                          TextBlock.verticalAlignment VerticalAlignment.Center ] ]
+                                      | InProgress, _
+                                      | NotStarted, Some _ ->
+                                          [ TextBlock.create
+                                                [ TextBlock.text "Loading"
+                                                  TextBlock.horizontalAlignment HorizontalAlignment.Center
+                                                  TextBlock.verticalAlignment VerticalAlignment.Center ] ]
 
-              | NotStarted, None -> [ inputTokenView state dispatch false ]
-              | Error ex, _ -> [ inputTokenView state dispatch true ]
-          ) ]
+                                      | NotStarted, None -> [ inputTokenView state dispatch false ]
+                                      | Error ex, _ -> [ inputTokenView state dispatch true ]
+                                  ) ] ] ] ] ]

--- a/src/Login.fs
+++ b/src/Login.fs
@@ -1,0 +1,123 @@
+[<RequireQualifiedAccess>]
+module Login
+
+open System
+open System.Data
+open Elmish
+open Avalonia.FuncUI
+open Avalonia.FuncUI.Types
+open Avalonia.FuncUI.DSL
+open Avalonia.Controls
+open Avalonia.Layout
+open Avalonia.Media.Imaging
+open Avalonia.Platform
+open Avalonia.Svg.Skia
+open ElmishUtility
+
+open Wanikani
+open MetaType
+
+type Msg =
+    | UseToken of string option
+    | TokenInputChanged of string
+    | SaveToken
+    | FetchUserAttempt of AsyncOp<Object<User>>
+    | LoggedIn of token: string * user: Object<User>
+
+type State =
+    { token: string option
+      tokenInput: string option
+      userFetchAttempt: AsyncOp<Object<User>> }
+
+let conn = Database.connection ()
+
+let init () =
+    { token = None
+      tokenInput = None
+      userFetchAttempt = NotStarted },
+    Cmd.OfAsync.perform AccessToken.tryGet conn UseToken
+
+let update (msg: Msg) (state: State) : State * Cmd<Msg> =
+    match msg with
+    | TokenInputChanged input -> { state with tokenInput = Some input }, Cmd.none
+    | UseToken(Some token) ->
+        { state with
+            token = Some token
+            tokenInput = None
+            userFetchAttempt = InProgress },
+        Cmd.OfAsync.either User.request token (Finished >> FetchUserAttempt) (Error >> FetchUserAttempt)
+    | UseToken None ->
+        Cmd.OfAsync.start (AccessToken.delete conn)
+
+        { state with
+            token = None
+            tokenInput = None
+            userFetchAttempt = NotStarted },
+        Cmd.none
+    | SaveToken ->
+        match state.tokenInput with
+        | Some input ->
+            { state with tokenInput = None },
+            Cmd.OfAsync.perform (AccessToken.save conn) input (fun _ -> UseToken state.tokenInput)
+        | None -> state, Cmd.none
+    | FetchUserAttempt(Error e) ->
+        Cmd.OfAsync.start (AccessToken.delete conn)
+
+        { state with
+            userFetchAttempt = Error e
+            token = None },
+        Cmd.none
+    | FetchUserAttempt(Finished user) ->
+        { state with
+            userFetchAttempt = Finished user },
+        Cmd.ofMsg (LoggedIn(state.token.Value, user))
+    | FetchUserAttempt user -> { state with userFetchAttempt = user }, Cmd.none
+    | LoggedIn _ -> state, Cmd.none // Handled on App.fs
+
+[<RequireQualifiedAccess>]
+module Icons =
+    let user =
+        lazy new SvgImage(Source = SvgSource.Load("avares://Wanigraphy/Assets/Icons/turtle.svg", null))
+
+let inputTokenView (state: State) (dispatch: Msg -> unit) (hasErrors: bool) : IView =
+    StackPanel.create
+        [ StackPanel.orientation Orientation.Horizontal
+          StackPanel.horizontalAlignment HorizontalAlignment.Center
+          StackPanel.verticalAlignment VerticalAlignment.Center
+          StackPanel.spacing 10
+          StackPanel.children
+              [ TextBox.create
+                    [ TextBox.passwordChar '*'
+                      TextBox.width 400
+                      TextBox.verticalAlignment VerticalAlignment.Top
+                      TextBox.hasErrors hasErrors
+                      TextBox.onTextChanged (fun input ->
+                          if String.IsNullOrWhiteSpace input |> not then
+                              TokenInputChanged input |> dispatch) ]
+                Button.create
+                    [ Button.onClick (fun _ -> dispatch SaveToken)
+                      // Button.isEnabled (Option.isSome inputValue)
+                      Button.verticalAlignment VerticalAlignment.Top
+                      Button.content "Login" ] ] ]
+
+let view (state: State) (dispatch: Msg -> unit) =
+    DockPanel.create
+        [ DockPanel.children (
+              match state.userFetchAttempt, state.token with
+              | Finished user, Some token -> []
+
+              | Finished user, None ->
+                  [ TextBlock.create
+                        [ TextBlock.text "Unexpected error"
+                          TextBlock.verticalAlignment VerticalAlignment.Center ] ]
+
+              | InProgress, _
+              | NotStarted, Some _ ->
+                  [ TextBlock.create
+                        [ TextBlock.text "Loading"
+                          TextBlock.horizontalAlignment HorizontalAlignment.Center
+                          TextBlock.verticalAlignment VerticalAlignment.Center ] ]
+
+              | NotStarted, None -> [ inputTokenView state dispatch false ]
+              | Error ex, _ -> [ inputTokenView state dispatch true ]
+          ) ]

--- a/src/Login.fs
+++ b/src/Login.fs
@@ -29,7 +29,7 @@ type State =
       tokenInput: string option
       userFetchAttempt: AsyncOp<Object<User>> }
 
-let conn = Database.connection ()
+let conn = Database.connection
 
 let init () =
     { token = None

--- a/src/Program.fs
+++ b/src/Program.fs
@@ -1,40 +1,5 @@
 ﻿namespace WanigraphyApp
 
-open FsHttp
-open Wanikani
-open Database
-
-// async {
-//     // Connect and initialize db
-//     use! conn = Database.connection
-//     do! Database.createIfNotExist conn
-
-//     // Get user access token from either db or the user
-//     let! token = AccessToken.get conn
-
-//     // Fetch the resources not stored in cache straight from the Wanikani API
-//     let! user = User.request token
-//     let! summary = Summary.request token
-
-//     // Fetch and save latest changes of resources resources that are stored in cache
-//     do!
-//         [ ReviewStatistics.refresh conn token
-//           Assignment.refresh conn token
-//           LevelProgression.refresh conn token
-//           Review.refresh conn token ]
-//         |> Async.Parallel
-//         |> Async.Ignore
-
-//     // Read the updated resources from cache
-//     let! reviewStatistics = ReviewStatistics.getCached conn
-//     let! assignments = Assignment.getCached conn
-//     let! levelProgression = LevelProgression.getCached conn
-//     let! review = Review.getCached conn
-
-//     return 0
-// }
-// |> Async.RunSynchronously
-
 open Avalonia
 open Avalonia.Controls
 open Avalonia.Themes.Fluent
@@ -44,6 +9,9 @@ open Avalonia.FuncUI
 open Avalonia.FuncUI.Elmish
 open Avalonia.Controls.ApplicationLifetimes
 
+open FsHttp
+open Wanikani
+open Database
 open App
 
 type MainWindow() as this =

--- a/src/Program.fs
+++ b/src/Program.fs
@@ -20,8 +20,8 @@ type MainWindow() as this =
     do
         base.Title <- "Wanigraphy"
         base.Icon <- WindowIcon(System.IO.Path.Combine("Assets", "Icons", "turtle.ico"))
-        base.Height <- 2000.0
-        base.Width <- 2000.0
+        base.Height <- 2000
+        base.Width <- 2000
 
         Elmish.Program.mkProgram App.init App.update App.view
         |> Program.withHost this

--- a/src/UserOverview.fs
+++ b/src/UserOverview.fs
@@ -1,0 +1,84 @@
+[<RequireQualifiedAccess>]
+module UserOverview
+
+open System
+open System.Data
+open Elmish
+open Avalonia.FuncUI
+open Avalonia.FuncUI.Types
+open Avalonia.FuncUI.DSL
+open Avalonia.Controls
+open Avalonia.Layout
+open Avalonia.Media.Imaging
+open Avalonia.Platform
+open Avalonia.Svg.Skia
+open ElmishUtility
+
+open Wanikani
+open MetaType
+
+type Msg =
+    | Logout
+    | ClearDatabase
+
+type State = { token: string; user: Object<User> }
+
+let conn = Database.connection ()
+
+let init token user =
+    { token = token; user = user }, Cmd.none
+
+let update (msg: Msg) (state: State) : State * Cmd<Msg> =
+    match msg with
+    | Logout -> state, Cmd.none // Handled on App.fs
+    | ClearDatabase -> state, Cmd.OfAsync.perform deleteStoredData conn (fun _ -> Logout)
+
+[<RequireQualifiedAccess>]
+module Icons =
+    let user =
+        lazy new SvgImage(Source = SvgSource.Load("avares://Wanigraphy/Assets/Icons/turtle.svg", null))
+
+let view ({ user = user }: State) (dispatch: Msg -> unit) =
+    DockPanel.create
+        [ DockPanel.children
+              [ StackPanel.create
+                    [ StackPanel.orientation Orientation.Horizontal
+                      StackPanel.horizontalAlignment HorizontalAlignment.Right
+                      StackPanel.dock Dock.Top
+                      StackPanel.margin 10
+                      StackPanel.children
+                          [ Button.create
+                                [ Button.content (
+                                      StackPanel.create
+                                          [ StackPanel.orientation Orientation.Horizontal
+                                            StackPanel.spacing 10
+                                            StackPanel.children
+                                                [ TextBlock.create
+                                                      [ TextBlock.text user.data.username
+                                                        TextBlock.verticalAlignment VerticalAlignment.Center
+                                                        TextBlock.fontSize 16 ]
+
+                                                  Image.create
+                                                      [ Image.source Icons.user.Value; Image.height 25; Image.width 25 ] ] ]
+                                  )
+                                  Button.flyout (
+                                      MenuFlyout.create
+                                          [ MenuFlyout.placement PlacementMode.BottomEdgeAlignedRight
+                                            MenuFlyout.showMode FlyoutShowMode.TransientWithDismissOnPointerMoveAway
+                                            MenuFlyout.viewItems
+                                                [ MenuItem.create
+                                                      [ MenuItem.header "Logout"
+                                                        MenuItem.onClick (fun _ -> dispatch ClearDatabase) ] ] ]
+                                  ) ] ] ]
+                StackPanel.create
+                    [ StackPanel.orientation Orientation.Horizontal
+                      StackPanel.horizontalAlignment HorizontalAlignment.Center
+                      StackPanel.verticalAlignment VerticalAlignment.Center
+                      StackPanel.spacing 10
+                      StackPanel.children
+                          [ TextBlock.create
+                                [ TextBlock.fontSize 48
+                                  TextBlock.verticalAlignment VerticalAlignment.Center
+                                  TextBlock.text $"Welcome {user.data.username}" ] ] ] ]
+
+          ]

--- a/src/Utility.fs
+++ b/src/Utility.fs
@@ -1,10 +1,6 @@
 [<AutoOpen>]
 module Utility
 
-module Async =
-    let bind f computation = async.Bind(computation, f)
-    let map f = bind (f >> async.Return)
-
 open System.Text.Json
 open System.Text.Json.Serialization
 
@@ -23,3 +19,27 @@ let serialize data =
 
 let deserialize<'T> (data: string) =
     JsonSerializer.Deserialize<'T>(data, serializerOptions)
+
+module Async =
+    let bind f computation = async.Bind(computation, f)
+    let map f = bind (f >> async.Return)
+
+[<RequireQualifiedAccess>]
+module Color =
+
+    open Avalonia.Media
+
+    let internal b (i: uint) = System.Convert.ToByte(i)
+
+    let background = Color.FromRgb(b 44u, b 51u, b 51u)
+    let primary = Color.FromRgb(b 46u, b 79u, b 79u)
+    let secondary = Color.FromRgb(b 14u, b 131u, b 136u)
+    let accent = Color.FromRgb(b 203u, b 228u, b 222u)
+
+[<RequireQualifiedAccess>]
+module Icons =
+
+    open Avalonia.Svg.Skia
+
+    let user =
+        lazy new SvgImage(Source = SvgSource.Load("avares://Wanigraphy/Assets/Icons/turtle.svg", null))

--- a/src/Wanigraphy.fsproj
+++ b/src/Wanigraphy.fsproj
@@ -10,6 +10,8 @@
     <Compile Include="Database.fs" />
     <Compile Include="Wanikani.fs" />
     <Compile Include="ElmishUtility.fs" />
+    <Compile Include="UserOverview.fs" />
+    <Compile Include="Login.fs" />
     <Compile Include="App.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>

--- a/src/Wanikani.fs
+++ b/src/Wanikani.fs
@@ -205,6 +205,9 @@ module Assignment =
 
     let getCached = getAllSaved<Assignment>
 
+    let refreshAndRead conn token =
+        refresh conn token |> Async.bind (fun _ -> getCached conn)
+
     let delete = deleteAllRows<Assignment>
 
 module Review =
@@ -216,6 +219,9 @@ module Review =
         fetchAndSaveChanges conn (request token) insertOrReplaceMultiple
 
     let getCached = getAllSaved<Review>
+
+    let refreshAndRead conn token =
+        refresh conn token |> Async.bind (fun _ -> getCached conn)
 
     let delete = deleteAllRows<Review>
 
@@ -229,6 +235,9 @@ module ReviewStatistics =
 
     let getCached = getAllSaved<ReviewStatistics>
 
+    let refreshAndRead conn token =
+        refresh conn token |> Async.bind (fun _ -> getCached conn)
+
     let delete = deleteAllRows<ReviewStatistics>
 
 module LevelProgression =
@@ -240,6 +249,9 @@ module LevelProgression =
         fetchAndSaveChanges conn (request token) insertOrReplaceMultiple
 
     let getCached = getAllSaved<LevelProgression>
+
+    let refreshAndRead conn token =
+        refresh conn token |> Async.bind (fun _ -> getCached conn)
 
     let delete = deleteAllRows<LevelProgression>
 

--- a/src/Wanikani.fs
+++ b/src/Wanikani.fs
@@ -205,6 +205,8 @@ module Assignment =
 
     let getCached = getAllSaved<Assignment>
 
+    let delete = deleteAllRows<Assignment>
+
 module Review =
 
     let request token since =
@@ -214,6 +216,8 @@ module Review =
         fetchAndSaveChanges conn (request token) insertOrReplaceMultiple
 
     let getCached = getAllSaved<Review>
+
+    let delete = deleteAllRows<Review>
 
 module ReviewStatistics =
 
@@ -225,6 +229,8 @@ module ReviewStatistics =
 
     let getCached = getAllSaved<ReviewStatistics>
 
+    let delete = deleteAllRows<ReviewStatistics>
+
 module LevelProgression =
 
     let request token since =
@@ -235,6 +241,8 @@ module LevelProgression =
 
     let getCached = getAllSaved<LevelProgression>
 
+    let delete = deleteAllRows<LevelProgression>
+
 module AccessToken =
 
     let tryGet conn =
@@ -244,3 +252,12 @@ module AccessToken =
         insertOrReplace conn { Table.token = token }
 
     let delete conn = deleteAllRows<Table.AccessToken> conn
+
+let deleteStoredData conn =
+    [ Assignment.delete
+      Review.delete
+      ReviewStatistics.delete
+      LevelProgression.delete
+      AccessToken.delete ]
+    |> List.map (fun op -> op conn)
+    |> Async.Parallel


### PR DESCRIPTION
Divide logging and main view into separate sub applications and manage them from the parent app. This creates a separation of concern between the two views and allows to create more accurate sub application states.

Hook the previously made domain model functions to be part of the main view sub application. Now after login the app checks for each data set their last update time and fetches updates after that from the API. The updates are then inserted into the database and finally read with the old data into the application state.

Now on logout deletes all data sets instead of just the access token.

Update fantomas dotnet tool.

Update dependencies.

Remove the top bar and flyout context button in favor of grids and
splitview panel.

Add basic side panel functionality and layout for both closed and opened
panel.

Add Colors module to create a color palette.