### PR TITLE
UI Facelift, improved login, and user highlights

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fantomas": {
-      "version": "6.3.3",
+      "version": "6.3.4",
       "commands": [
         "fantomas"
       ]

--- a/paket.lock
+++ b/paket.lock
@@ -25,12 +25,12 @@ NUGET
     Avalonia.FreeDesktop (11.0.10) - restriction: >= netstandard2.0
       Avalonia (>= 11.0.10) - restriction: >= netstandard2.0
       Tmds.DBus.Protocol (>= 0.15) - restriction: >= netstandard2.0
-    Avalonia.FuncUI (1.3)
+    Avalonia.FuncUI (1.4)
       Avalonia (>= 11.0) - restriction: >= net6.0
       Avalonia.Controls.DataGrid (>= 11.0) - restriction: >= net6.0
       FSharp.Core (>= 8.0.200) - restriction: >= net6.0
-    Avalonia.FuncUI.Elmish (1.3)
-      Avalonia.FuncUI (>= 1.3) - restriction: >= net6.0
+    Avalonia.FuncUI.Elmish (1.4)
+      Avalonia.FuncUI (>= 1.4) - restriction: >= net6.0
       Elmish (>= 4.0) - restriction: >= net6.0
       FSharp.Core (>= 8.0.200) - restriction: >= net6.0
     Avalonia.Native (11.0.10) - restriction: >= netstandard2.0
@@ -186,7 +186,7 @@ NUGET
     System.Threading.Tasks.Extensions (4.5.4) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (>= net462) (>= netstandard2.0)) (&& (< net6.0) (>= netcoreapp2.0)) (&& (< netcoreapp2.0) (>= netstandard2.0)) (&& (>= netstandard2.0) (< netstandard2.1))
       System.Runtime.CompilerServices.Unsafe (>= 4.5.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.0) (>= portable-net45+win8+wp8+wpa81) (< win8)) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net461) (&& (< netstandard1.0) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= wp8)
     System.ValueTuple (4.5) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (>= net462) (>= netstandard2.0)) (&& (< net6.0) (>= netcoreapp2.0)) (&& (< netcoreapp2.0) (>= netstandard2.0))
-    Tmds.DBus.Protocol (0.16) - restriction: >= netstandard2.0
+    Tmds.DBus.Protocol (0.18) - restriction: >= netstandard2.0
       Microsoft.Bcl.AsyncInterfaces (>= 8.0) - restriction: || (&& (< net6.0) (>= netstandard2.1)) (&& (>= netstandard2.0) (< netstandard2.1))
-      System.IO.Pipelines (>= 6.0) - restriction: >= netstandard2.0
+      System.IO.Pipelines (>= 8.0) - restriction: >= netstandard2.0
       System.Threading.Channels (>= 8.0) - restriction: || (&& (< net6.0) (>= netstandard2.1)) (&& (>= netstandard2.0) (< netstandard2.1))

--- a/src/App.fs
+++ b/src/App.fs
@@ -17,18 +17,18 @@ open Wanikani
 open MetaType
 
 type View =
-    | Login
-    | UserOverview
+    | LoginView
+    | MainView
 
 type Msg =
     | DbInitialized
     | LoginMsg of Login.Msg
-    | UserOverviewMsg of UserOverview.Msg
+    | MainMsg of MainView.Msg
 
 type State =
     { currentView: View
       login: Login.State
-      user: UserOverview.State option }
+      main: MainView.State option }
 
 let conn = Database.connection
 
@@ -36,9 +36,9 @@ let init () =
     let loginState, loginCmd = Login.init ()
 
     let initialState =
-        { currentView = Login
+        { currentView = LoginView
           login = loginState
-          user = None }
+          main = None }
 
     let initialCmd =
         Cmd.batch
@@ -51,31 +51,27 @@ let update (msg: Msg) (state: State) : State * Cmd<Msg> =
     match msg with
     | DbInitialized -> state, Cmd.none
     | LoginMsg(Login.LoggedIn(token, user)) ->
-        let userState, userCmd = UserOverview.init token user
+        let mainState, mainCmd = MainView.init token user
 
         { state with
             login = Login.init () |> fst
-            user = Some userState
-            currentView = UserOverview },
-        Cmd.map UserOverviewMsg userCmd
+            main = Some mainState
+            currentView = MainView },
+        Cmd.map MainMsg mainCmd
     | LoginMsg loginMsg ->
         let loginState, loginCmd = Login.update loginMsg state.login
 
         { state with login = loginState }, Cmd.map LoginMsg loginCmd
-    | UserOverviewMsg UserOverview.Logout ->
+    | MainMsg MainView.Logout ->
         { state with
-            user = None
-            currentView = Login },
+            main = None
+            currentView = LoginView },
         Cmd.none
-    | UserOverviewMsg userMsg ->
-        let userOverviewState, userOverviewCmd =
-            UserOverview.update userMsg state.user.Value
-
-        { state with
-            user = Some userOverviewState },
-        Cmd.map UserOverviewMsg userOverviewCmd
+    | MainMsg mainMsg ->
+        let mainState, mainCmd = MainView.update mainMsg state.main.Value
+        { state with main = Some mainState }, Cmd.map MainMsg mainCmd
 
 let view (state: State) (dispatch: Msg -> unit) =
     match state.currentView with
-    | Login -> Login.view state.login (LoginMsg >> dispatch)
-    | UserOverview -> UserOverview.view state.user.Value (UserOverviewMsg >> dispatch)
+    | LoginView -> Login.view state.login (LoginMsg >> dispatch)
+    | MainView -> MainView.view state.main.Value (MainMsg >> dispatch)

--- a/src/App.fs
+++ b/src/App.fs
@@ -68,8 +68,11 @@ let update (msg: Msg) (state: State) : State * Cmd<Msg> =
             currentView = LoginView },
         Cmd.none
     | MainMsg mainMsg ->
-        let mainState, mainCmd = MainView.update mainMsg state.main.Value
-        { state with main = Some mainState }, Cmd.map MainMsg mainCmd
+        match state.main with
+        | Some main ->
+            let mainState, mainCmd = MainView.update mainMsg main
+            { state with main = Some mainState }, Cmd.map MainMsg mainCmd
+        | None -> state, Cmd.none
 
 let view (state: State) (dispatch: Msg -> unit) =
     match state.currentView with

--- a/src/Highlights.fs
+++ b/src/Highlights.fs
@@ -1,0 +1,236 @@
+module Highlights
+
+open System
+open System.Collections.Generic
+open Avalonia.FuncUI
+open Avalonia.FuncUI.Types
+open Avalonia.FuncUI.DSL
+open Avalonia.Controls
+open Avalonia.Layout
+open Avalonia.Media
+open Avalonia.Platform
+open Avalonia.Svg.Skia
+open ElmishUtility
+
+open MetaType
+
+[<RequireQualifiedAccess>]
+module SrsStage =
+
+    open Wanikani
+
+    type Stage =
+        { name: string
+          subStageName: string option }
+
+    let subCountText row column text =
+        TextBlock.create
+            [ Grid.row row
+              Grid.column column
+              TextBlock.fontSize 14
+              TextBlock.verticalAlignment VerticalAlignment.Center
+              TextBlock.horizontalAlignment HorizontalAlignment.Center
+              TextBlock.text text ]
+
+    let stageName row column columnSpan name =
+        TextBlock.create
+            [ Grid.row row
+              Grid.column column
+              Grid.columnSpan columnSpan
+              TextBlock.fontSize 18
+              TextBlock.verticalAlignment VerticalAlignment.Center
+              TextBlock.horizontalAlignment HorizontalAlignment.Center
+              TextBlock.text name ]
+
+    let stagePanels
+        (apprentice: Stage[] option)
+        (guru: Stage[] option)
+        (master: Stage[] option)
+        (enlightened: Stage[] option)
+        (burned: Stage[] option)
+        =
+        let tryGet (id: string) (d: IDictionary<string, int>) =
+            match d.TryGetValue(id) with
+            | true, value -> Some value
+            | _ -> Some 0
+            |> Option.map string
+
+        let getOrEmpty name =
+            Option.bind (tryGet "name") >> Option.defaultValue ""
+
+        let subCounts =
+            Option.map (Array.countBy (_.subStageName >> Option.defaultValue "") >> dict)
+
+        let subApprentices = subCounts apprentice
+        let apprenticeI = subApprentices |> getOrEmpty "I"
+        let apprenticeII = subApprentices |> getOrEmpty "II"
+        let apprenticeIII = subApprentices |> getOrEmpty "III"
+        let apprenticeIV = subApprentices |> getOrEmpty "IV"
+
+        let subGurus = subCounts guru
+        let guruI = subGurus |> getOrEmpty "I"
+        let guruII = subGurus |> getOrEmpty "II"
+
+
+        StackPanel.create
+            [ StackPanel.orientation Orientation.Horizontal
+              StackPanel.spacing 10
+              StackPanel.children
+                  [ // Apprentice
+                    Grid.create
+                        [ Grid.rowDefinitions "* 35 25"
+                          Grid.columnDefinitions "60 60 60 60"
+                          Grid.verticalAlignment VerticalAlignment.Center
+                          Grid.horizontalAlignment HorizontalAlignment.Center
+                          Grid.width 240
+                          Grid.height 140
+                          Grid.background Color.apprentice
+                          Grid.children
+                              [ TextBlock.create
+                                    [ Grid.row 0
+                                      Grid.column 0
+                                      Grid.columnSpan 4
+                                      TextBlock.verticalAlignment VerticalAlignment.Center
+                                      TextBlock.horizontalAlignment HorizontalAlignment.Center
+                                      TextBlock.fontSize 28
+                                      TextBlock.text (
+                                          apprentice |> Option.map (Array.length >> string) |> Option.defaultValue ""
+                                      ) ]
+
+                                subCountText 1 0 $"I: {apprenticeI}"
+                                subCountText 1 1 $"II: {apprenticeII}"
+                                subCountText 1 2 $"III: {apprenticeIII}"
+                                subCountText 1 3 $"IV: {apprenticeIV}"
+
+                                stageName 2 0 4 "Apprentice" ] ]
+
+                    // Guru
+                    Grid.create
+                        [ Grid.rowDefinitions "* 35 25"
+                          Grid.columnDefinitions "60 60 60 60"
+                          Grid.width 240
+                          Grid.height 140
+                          Grid.background Color.guru
+                          Grid.children
+                              [ TextBlock.create
+                                    [ Grid.row 0
+                                      Grid.column 0
+                                      Grid.columnSpan 4
+                                      TextBlock.verticalAlignment VerticalAlignment.Center
+                                      TextBlock.horizontalAlignment HorizontalAlignment.Center
+                                      TextBlock.fontSize 28
+                                      TextBlock.text (
+                                          guru |> Option.map (Array.length >> string) |> Option.defaultValue ""
+                                      ) ]
+
+                                subCountText 1 1 $"I: {guruI}"
+                                subCountText 1 2 $"II: {guruII}"
+
+                                stageName 2 0 4 "Guru"
+
+                                ] ]
+
+                    // Master
+                    Grid.create
+                        [ Grid.rowDefinitions "* 35 25"
+                          Grid.width 240
+                          Grid.height 140
+                          Grid.background Color.master
+                          Grid.children
+                              [ TextBlock.create
+                                    [ Grid.row 0
+                                      TextBlock.verticalAlignment VerticalAlignment.Center
+                                      TextBlock.horizontalAlignment HorizontalAlignment.Center
+                                      TextBlock.fontSize 28
+                                      TextBlock.text (
+                                          master |> Option.map (Array.length >> string) |> Option.defaultValue ""
+                                      ) ]
+                                stageName 2 0 1 "Master" ] ]
+
+                    // Enlightened
+                    Grid.create
+                        [ Grid.rowDefinitions "* 35 25"
+                          Grid.width 240
+                          Grid.height 140
+                          Grid.background Color.enlightened
+                          Grid.children
+                              [ TextBlock.create
+                                    [ Grid.row 0
+                                      TextBlock.verticalAlignment VerticalAlignment.Center
+                                      TextBlock.horizontalAlignment HorizontalAlignment.Center
+                                      TextBlock.fontSize 28
+                                      TextBlock.text (
+                                          enlightened |> Option.map (Array.length >> string) |> Option.defaultValue ""
+                                      ) ]
+
+                                stageName 2 0 1 "enlightened" ] ]
+
+                    // Burned
+                    Grid.create
+                        [ Grid.rowDefinitions "* 35 25"
+                          Grid.width 240
+                          Grid.height 140
+                          Grid.background Color.burned
+                          Grid.children
+                              [ TextBlock.create
+                                    [ Grid.row 0
+                                      TextBlock.verticalAlignment VerticalAlignment.Center
+                                      TextBlock.horizontalAlignment HorizontalAlignment.Center
+                                      TextBlock.fontSize 28
+                                      TextBlock.text (
+                                          burned |> Option.map (Array.length >> string) |> Option.defaultValue ""
+                                      ) ]
+
+                                stageName 2 0 1 "Burned" ] ]
+
+                    ] ]
+
+    let countView (assignments: AsyncOp<Resource<Assignment>[]>) =
+        match assignments with
+        | Finished assignments ->
+            let stages =
+                assignments
+                |> Array.map (
+                    _.data
+                    >> _.srs_stage
+                    >> function
+                        | SrsStage.Initiate ->
+                            { name = "Initiate"
+                              subStageName = None }
+                        | SrsStage.Apprentice1 ->
+                            { name = "Apprentice"
+                              subStageName = Some "I" }
+                        | SrsStage.Apprentice2 ->
+                            { name = "Apprentice"
+                              subStageName = Some "II" }
+                        | SrsStage.Apprentice3 ->
+                            { name = "Apprentice"
+                              subStageName = Some "III" }
+                        | SrsStage.Apprentice4 ->
+                            { name = "Apprentice"
+                              subStageName = Some "IV" }
+                        | SrsStage.Guru1 ->
+                            { name = "Guru"
+                              subStageName = Some "I" }
+                        | SrsStage.Guru2 ->
+                            { name = "Guru"
+                              subStageName = Some "II" }
+                        | SrsStage.Master -> { name = "Master"; subStageName = None }
+                        | SrsStage.Enlightened ->
+                            { name = "Enlightened"
+                              subStageName = None }
+                        | SrsStage.Burned -> { name = "Burned"; subStageName = None }
+                        | s -> failwithf "Invalid stage: %A" s
+                )
+                |> Array.groupBy _.name
+                |> Array.filter (fst >> (<>) "Initiate")
+                |> dict
+
+            stagePanels
+                (Some stages["Apprentice"])
+                (Some stages["Guru"])
+                (Some stages["Master"])
+                (Some stages["Enlightened"])
+                (Some stages["Burned"])
+
+        | _ -> stagePanels None None None None None

--- a/src/Login.fs
+++ b/src/Login.fs
@@ -8,7 +8,9 @@ open Avalonia.FuncUI
 open Avalonia.FuncUI.Types
 open Avalonia.FuncUI.DSL
 open Avalonia.Controls
+open Avalonia.Input
 open Avalonia.Layout
+open Avalonia.Media
 open Avalonia.Media.Imaging
 open Avalonia.Platform
 open Avalonia.Svg.Skia
@@ -56,10 +58,10 @@ let update (msg: Msg) (state: State) : State * Cmd<Msg> =
         Cmd.none
     | SaveToken ->
         match state.tokenInput with
-        | Some input ->
+        | Some input when input.Length = 36 ->
             { state with tokenInput = None },
             Cmd.OfAsync.perform (AccessToken.save conn) input (fun _ -> UseToken state.tokenInput)
-        | None -> state, Cmd.none
+        | _ -> state, Cmd.none
     | FetchUserAttempt(Error e) ->
         Cmd.OfAsync.start (AccessToken.delete conn)
 
@@ -80,49 +82,95 @@ module Icons =
         lazy new SvgImage(Source = SvgSource.Load("avares://Wanigraphy/Assets/Icons/turtle.svg", null))
 
 let inputTokenView (state: State) (dispatch: Msg -> unit) (hasErrors: bool) : IView =
+    let errors =
+        seq {
+            if hasErrors then
+                yield "Invalid API token"
+
+            if
+                state.tokenInput
+                |> Option.exists (fun input -> input.Length > 0 && input.Length <> 36)
+            then
+                yield $"{state.tokenInput.Value.Length} out of 36 characters"
+        }
+        |> Seq.map box
+
+    let hasCorrectLength =
+        state.tokenInput |> Option.exists (fun input -> input.Length = 36)
+
     StackPanel.create
-        [ StackPanel.orientation Orientation.Horizontal
-          StackPanel.horizontalAlignment HorizontalAlignment.Center
-          StackPanel.verticalAlignment VerticalAlignment.Center
-          StackPanel.spacing 10
+        [ StackPanel.orientation Orientation.Vertical
+          StackPanel.spacing 5
           StackPanel.children
-              [ TextBox.create
-                    [ TextBox.passwordChar '*'
-                      TextBox.width 400
-                      TextBox.verticalAlignment VerticalAlignment.Top
-                      TextBox.hasErrors hasErrors
-                      TextBox.onTextChanged (fun input ->
-                          if String.IsNullOrWhiteSpace input |> not then
-                              TokenInputChanged input |> dispatch) ]
-                Button.create
-                    [ Button.onClick (fun _ -> dispatch SaveToken)
-                      // Button.isEnabled (Option.isSome inputValue)
-                      Button.verticalAlignment VerticalAlignment.Top
-                      Button.content "Login" ] ] ]
+              [ TextBlock.create [ TextBlock.text "Personal API Token" ]
+
+                StackPanel.create
+                    [ StackPanel.orientation Orientation.Horizontal
+                      StackPanel.verticalAlignment VerticalAlignment.Top
+                      StackPanel.spacing 10
+                      StackPanel.children
+                          [ TextBox.create
+                                [ TextBox.width 400
+                                  TextBox.minHeight 35
+                                  TextBox.fontSize 18
+                                  TextBox.watermark "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+                                  TextBox.passwordChar '*'
+                                  TextBox.tip "Get your personal API token from Wanikani settings"
+                                  TextBox.hasErrors hasErrors
+                                  TextBox.errors errors
+                                  TextBox.onTextChanged (Option.ofObj >> Option.iter (TokenInputChanged >> dispatch))
+                                  TextBox.onKeyDown (fun evt ->
+                                      if evt.Key = Key.Return then
+                                          dispatch SaveToken) ]
+                            Button.create
+                                [ Button.verticalAlignment VerticalAlignment.Top
+                                  Button.height 35
+                                  Button.onClick (fun _ -> dispatch SaveToken)
+                                  Button.isEnabled hasCorrectLength
+                                  Button.content (
+                                      TextBlock.create
+                                          [ TextBlock.verticalAlignment VerticalAlignment.Center
+                                            TextBlock.horizontalAlignment HorizontalAlignment.Center
+                                            TextBlock.text "Login" ]
+                                  ) ] ] ] ] ]
 
 let view (state: State) (dispatch: Msg -> unit) =
     Grid.create
-        [ Grid.children
-              [ StackPanel.create
-                    [ StackPanel.children
-                          [ DockPanel.create
-                                [ DockPanel.background Color.background
-                                  DockPanel.children (
-                                      match state.userFetchAttempt, state.token with
-                                      | Finished user, Some token -> []
+        [ Grid.rowDefinitions "250, auto, *"
+          Grid.columnDefinitions "*, auto, *"
+          Grid.background Color.background
+          Grid.children
+              [ TextBlock.create
+                    [ Grid.row 0
+                      Grid.column 1
+                      TextBlock.verticalAlignment VerticalAlignment.Center
+                      TextBlock.text "Wanigraphy"
+                      TextBlock.fontSize 60
+                      TextBlock.textAlignment TextAlignment.Center ]
 
-                                      | Finished user, None ->
-                                          [ TextBlock.create
-                                                [ TextBlock.text "Unexpected error"
-                                                  TextBlock.verticalAlignment VerticalAlignment.Center ] ]
+                Panel.create
+                    [ Grid.row 1
+                      Grid.column 1
+                      Panel.height 60
+                      Panel.children (
+                          match state.userFetchAttempt, state.token with
+                          | Finished user, Some token -> []
 
-                                      | InProgress, _
-                                      | NotStarted, Some _ ->
-                                          [ TextBlock.create
-                                                [ TextBlock.text "Loading"
-                                                  TextBlock.horizontalAlignment HorizontalAlignment.Center
-                                                  TextBlock.verticalAlignment VerticalAlignment.Center ] ]
+                          | Finished user, None ->
+                              [ TextBlock.create
+                                    [ TextBlock.text "Unexpected error"
+                                      TextBlock.fontSize 20
+                                      TextBlock.horizontalAlignment HorizontalAlignment.Center
+                                      TextBlock.verticalAlignment VerticalAlignment.Center ] ]
 
-                                      | NotStarted, None -> [ inputTokenView state dispatch false ]
-                                      | Error ex, _ -> [ inputTokenView state dispatch true ]
-                                  ) ] ] ] ] ]
+                          | InProgress, _
+                          | NotStarted, Some _ ->
+                              [ TextBlock.create
+                                    [ TextBlock.text "Loading..."
+                                      TextBlock.fontSize 20
+                                      TextBlock.horizontalAlignment HorizontalAlignment.Center
+                                      TextBlock.verticalAlignment VerticalAlignment.Center ] ]
+
+                          | NotStarted, None -> [ inputTokenView state dispatch false ]
+                          | Error ex, _ -> [ inputTokenView state dispatch true ]
+                      ) ] ] ]

--- a/src/MainView.fs
+++ b/src/MainView.fs
@@ -113,6 +113,13 @@ let update (msg: Msg) (state: State) : State * Cmd<Msg> =
 
         state, Cmd.none
 
+let WanigraphyIcon =
+    Image.create
+        [ Image.horizontalAlignment HorizontalAlignment.Center
+          Image.source Icons.user.Value
+          Image.height 40
+          Image.width 40 ]
+
 let view (state: State) (dispatch: Msg -> unit) =
     Grid.create
         [ Grid.background Color.background
@@ -136,13 +143,7 @@ let view (state: State) (dispatch: Msg -> unit) =
                             Grid.children (
                                 match state.isPaneOpen with
                                 | false ->
-                                    [ Image.create
-                                          [ Grid.row 1
-                                            Grid.column 1
-                                            Image.horizontalAlignment HorizontalAlignment.Center
-                                            Image.source Icons.user.Value
-                                            Image.height 40
-                                            Image.width 40 ] ]
+                                    [ Panel.create [ Grid.row 1; Grid.column 1; Panel.children [ WanigraphyIcon ] ] ]
                                 | true ->
                                     [ StackPanel.create
                                           [ Grid.row 1
@@ -151,11 +152,7 @@ let view (state: State) (dispatch: Msg -> unit) =
                                             StackPanel.orientation Orientation.Horizontal
                                             StackPanel.spacing 10
                                             StackPanel.children
-                                                [ Image.create
-                                                      [ Image.horizontalAlignment HorizontalAlignment.Center
-                                                        Image.source Icons.user.Value
-                                                        Image.height 40
-                                                        Image.width 40 ]
+                                                [ WanigraphyIcon
                                                   TextBlock.create
                                                       [ TextBlock.verticalAlignment VerticalAlignment.Bottom
                                                         TextBlock.fontSize 28

--- a/src/MainView.fs
+++ b/src/MainView.fs
@@ -1,5 +1,5 @@
 [<RequireQualifiedAccess>]
-module UserOverview
+module MainView
 
 open System
 open System.Data

--- a/src/MainView.fs
+++ b/src/MainView.fs
@@ -17,6 +17,7 @@ open Avalonia.Svg.Skia
 open ElmishUtility
 
 open Wanikani
+open Highlights
 open MetaType
 
 type Link = WanikaniProfile
@@ -120,6 +121,81 @@ let WanigraphyIcon =
           Image.height 40
           Image.width 40 ]
 
+let sidePanel state dispatch =
+    Grid.create
+        [ // Grid.showGridLines true
+          Grid.rowDefinitions "10, auto, 30, auto, auto, auto, *, auto"
+          Grid.columnDefinitions "10, *, 10"
+          Grid.children (
+              match state.isPaneOpen with
+              | false -> [ Panel.create [ Grid.row 1; Grid.column 1; Panel.children [ WanigraphyIcon ] ] ]
+              | true ->
+                  [ StackPanel.create
+                        [ Grid.row 1
+                          Grid.column 1
+                          StackPanel.margin 0
+                          StackPanel.orientation Orientation.Horizontal
+                          StackPanel.spacing 10
+                          StackPanel.children
+                              [ WanigraphyIcon
+                                TextBlock.create
+                                    [ TextBlock.verticalAlignment VerticalAlignment.Bottom
+                                      TextBlock.fontSize 28
+                                      TextBlock.fontWeight FontWeight.Bold
+                                      TextBlock.text "Wanigraphy" ] ] ]
+
+                    Separator.create [ Grid.row 2; Grid.column 0; Grid.columnSpan 3 ]
+
+                    TextBlock.create
+                        [ Grid.row 3
+                          Grid.column 1
+                          TextBlock.fontSize 20
+                          TextBlock.text state.user.data.username ]
+
+                    TextBlock.create
+                        [ Grid.row 4
+                          Grid.column 1
+                          TextBlock.margin (0, 1, 0, 0)
+                          TextBlock.text $"Level {state.user.data.level}" ]
+
+                    TextBlock.create
+                        [ Grid.row 5
+                          Grid.column 1
+                          TextBlock.margin (0, 10, 0, 0)
+                          TextBlock.classes [ "link" ]
+                          TextBlock.text "Go to profile"
+                          TextBlock.onTapped (fun _ -> dispatch (OpenUrl WanikaniProfile)) ]
+
+                    Button.create
+                        [ Grid.row 7
+                          Grid.column 0
+                          Grid.columnSpan 3
+                          Button.horizontalAlignment HorizontalAlignment.Stretch
+                          Button.height 60
+                          Button.background Color.secondary
+                          Button.content (
+                              TextBlock.create
+                                  [ TextBlock.horizontalAlignment HorizontalAlignment.Center
+                                    TextBlock.verticalAlignment VerticalAlignment.Center
+                                    TextBlock.fontSize 18
+                                    TextBlock.fontWeight FontWeight.Bold
+                                    TextBlock.text "Logout" ]
+                          )
+                          Button.onClick (fun _ -> dispatch ClearDatabase) ] ]
+          ) ]
+
+
+let mainContent (state: State) dispatch =
+    Grid.create
+        [ Grid.horizontalAlignment HorizontalAlignment.Center
+          Grid.rowDefinitions "auto auto"
+          Grid.children
+              [ Panel.create
+                    [ Grid.row 0
+                      Panel.margin (0, 10)
+                      Panel.children [ SrsStage.countView state.assignments ] ]
+                TextBlock.create [ Grid.row 1; TextBlock.text "Main content" ] ] ]
+
 let view (state: State) (dispatch: Msg -> unit) =
     Grid.create
         [ Grid.background Color.background
@@ -132,76 +208,14 @@ let view (state: State) (dispatch: Msg -> unit) =
                       SplitView.isPaneOpen state.isPaneOpen
                       SplitView.displayMode SplitViewDisplayMode.CompactOverlay
                       SplitView.useLightDismissOverlayMode true
-                      SplitView.onPointerEntered (fun _ -> dispatch OpenSplitViewPane)
+                      SplitView.onPointerEntered (fun e ->
+                          // Unfortunately, SplitView triggers this event on both pane, and content.
+                          // To send our event only on side pane pointer enter, we check the pointer position
+                          let point = e.GetPosition(null)
+
+                          if point.X < 60 then
+                              dispatch OpenSplitViewPane)
                       SplitView.onPointerExited (fun _ -> dispatch CloseSplitViewPane)
 
-
-                      Grid.create
-                          [ // Grid.showGridLines true
-                            Grid.rowDefinitions "10, auto, 30, auto, auto, auto, *, auto"
-                            Grid.columnDefinitions "10, *, 10"
-                            Grid.children (
-                                match state.isPaneOpen with
-                                | false ->
-                                    [ Panel.create [ Grid.row 1; Grid.column 1; Panel.children [ WanigraphyIcon ] ] ]
-                                | true ->
-                                    [ StackPanel.create
-                                          [ Grid.row 1
-                                            Grid.column 1
-                                            StackPanel.margin 0
-                                            StackPanel.orientation Orientation.Horizontal
-                                            StackPanel.spacing 10
-                                            StackPanel.children
-                                                [ WanigraphyIcon
-                                                  TextBlock.create
-                                                      [ TextBlock.verticalAlignment VerticalAlignment.Bottom
-                                                        TextBlock.fontSize 28
-                                                        TextBlock.fontWeight FontWeight.Bold
-                                                        TextBlock.text "Wanigraphy" ] ] ]
-
-                                      Separator.create [ Grid.row 2; Grid.column 0; Grid.columnSpan 3 ]
-
-                                      TextBlock.create
-                                          [ Grid.row 3
-                                            Grid.column 1
-                                            TextBlock.fontSize 20
-                                            TextBlock.text state.user.data.username ]
-
-                                      TextBlock.create
-                                          [ Grid.row 4
-                                            Grid.column 1
-                                            TextBlock.margin (0, 1, 0, 0)
-                                            TextBlock.text $"Level {state.user.data.level}" ]
-
-                                      TextBlock.create
-                                          [ Grid.row 5
-                                            Grid.column 1
-                                            TextBlock.margin (0, 10, 0, 0)
-                                            TextBlock.classes [ "link" ]
-                                            TextBlock.text "Go to profile"
-                                            TextBlock.onTapped (fun _ -> dispatch (OpenUrl WanikaniProfile)) ]
-
-                                      Button.create
-                                          [ Grid.row 7
-                                            Grid.column 0
-                                            Grid.columnSpan 3
-                                            Button.horizontalAlignment HorizontalAlignment.Stretch
-                                            Button.height 60
-                                            Button.background Color.secondary
-                                            Button.content (
-                                                TextBlock.create
-                                                    [ TextBlock.horizontalAlignment HorizontalAlignment.Center
-                                                      TextBlock.verticalAlignment VerticalAlignment.Center
-                                                      TextBlock.fontSize 18
-                                                      TextBlock.fontWeight FontWeight.Bold
-                                                      TextBlock.text "Logout" ]
-                                            )
-                                            Button.onClick (fun _ -> dispatch ClearDatabase) ] ]
-                            ) ]
-                      |> SplitView.pane
-
-                      Grid.create
-                          [ Grid.verticalAlignment VerticalAlignment.Center
-                            Grid.horizontalAlignment HorizontalAlignment.Center
-                            Grid.children [ TextBlock.create [ TextBlock.text "Main content" ] ] ]
-                      |> SplitView.content ] ] ]
+                      sidePanel state dispatch |> SplitView.pane
+                      mainContent state dispatch |> SplitView.content ] ] ]

--- a/src/Program.fs
+++ b/src/Program.fs
@@ -25,7 +25,7 @@ type MainWindow() as this =
 
         Elmish.Program.mkProgram App.init App.update App.view
         |> Program.withHost this
-        |> Program.withConsoleTrace
+        // |> Program.withConsoleTrace
         |> Program.runWithAvaloniaSyncDispatch ()
 
 type Wanigraphy() =
@@ -33,6 +33,7 @@ type Wanigraphy() =
 
     override this.Initialize() =
         this.Styles.Add(FluentTheme())
+        this.Styles.Load "avares://Wanigraphy/Styles.xaml"
         this.RequestedThemeVariant <- Styling.ThemeVariant.Dark
 
     override this.OnFrameworkInitializationCompleted() =

--- a/src/Styles.xaml
+++ b/src/Styles.xaml
@@ -1,0 +1,11 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+        
+    <Style Selector="TextBlock.link">
+        <Setter Property="Foreground" Value="#009bde" />
+    </Style>
+  
+    <Style Selector="TextBlock.link:pointerover">
+        <Setter Property="Foreground" Value="White" />
+    </Style>
+</Styles>

--- a/src/Utility.fs
+++ b/src/Utility.fs
@@ -29,12 +29,19 @@ module Color =
 
     open Avalonia.Media
 
-    let internal b (i: uint) = System.Convert.ToByte(i)
+    let internal byte (i: int) = System.Convert.ToByte(i)
+    let rgb r g b = Color.FromRgb(byte r, byte g, byte b)
 
-    let background = Color.FromRgb(b 44u, b 51u, b 51u)
-    let primary = Color.FromRgb(b 46u, b 79u, b 79u)
-    let secondary = Color.FromRgb(b 14u, b 131u, b 136u)
-    let accent = Color.FromRgb(b 203u, b 228u, b 222u)
+    let background = rgb 44 51 51
+    let primary = rgb 46 79 79
+    let secondary = rgb 14 131 136
+    let accent = rgb 203 228 222
+
+    let apprentice = rgb 221 0 147
+    let guru = rgb 136 45 158
+    let master = rgb 41 77 219
+    let enlightened = rgb 0 147 221
+    let burned = rgb 67 67 67
 
 [<RequireQualifiedAccess>]
 module Icons =

--- a/src/Wanigraphy.fsproj
+++ b/src/Wanigraphy.fsproj
@@ -10,6 +10,7 @@
     <Compile Include="Database.fs" />
     <Compile Include="Wanikani.fs" />
     <Compile Include="ElmishUtility.fs" />
+    <Compile Include="Highlights.fs" />
     <Compile Include="MainView.fs" />
     <Compile Include="Login.fs" />
     <Compile Include="App.fs" />

--- a/src/Wanigraphy.fsproj
+++ b/src/Wanigraphy.fsproj
@@ -10,7 +10,7 @@
     <Compile Include="Database.fs" />
     <Compile Include="Wanikani.fs" />
     <Compile Include="ElmishUtility.fs" />
-    <Compile Include="UserOverview.fs" />
+    <Compile Include="MainView.fs" />
     <Compile Include="Login.fs" />
     <Compile Include="App.fs" />
     <Compile Include="Program.fs" />

--- a/src/Wanigraphy.fsproj
+++ b/src/Wanigraphy.fsproj
@@ -17,6 +17,7 @@
   </ItemGroup>
   <ItemGroup>
     <AvaloniaResource Include="Assets\**"/>
+    <AvaloniaResource Include="**\*.xaml" />
   </ItemGroup>
   <Import Project="..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/Wanikani.fs
+++ b/src/Wanikani.fs
@@ -62,13 +62,46 @@ type SubjectType =
     | Vocabulary
     | [<JsonName "kana_vocabulary">] KanaVocabulary
 
+type SrsStage =
+    | Initiate = 0u
+    | Apprentice1 = 1u
+    | Apprentice2 = 2u
+    | Apprentice3 = 3u
+    | Apprentice4 = 4u
+    | Guru1 = 5u
+    | Guru2 = 6u
+    | Master = 7u
+    | Enlightened = 8u
+    | Burned = 9u
+
+type ReviewStartingSrsStage =
+    | Apprentice1 = 1u
+    | Apprentice2 = 2u
+    | Apprentice3 = 3u
+    | Apprentice4 = 4u
+    | Guru1 = 5u
+    | Guru2 = 6u
+    | Master = 7u
+    | Enlightened = 8u
+
+type ReviewEndingSrsStage =
+    | Apprentice1 = 1u
+    | Apprentice2 = 2u
+    | Apprentice3 = 3u
+    | Apprentice4 = 4u
+    | Guru1 = 5u
+    | Guru2 = 6u
+    | Master = 7u
+    | Enlightened = 8u
+    | Burned = 9u
+
 type Assignment =
     { available_at: DateTime option
       burned_at: DateTime option
       created_at: DateTime
       passed_at: DateTime option
       resurrected_at: DateTime option
-      srs_stage: uint
+      srs_stage: SrsStage
       started_at: DateTime
       subject_id: uint
       subject_type: SubjectType
@@ -77,11 +110,11 @@ type Assignment =
 type Review =
     { assignment_id: uint
       created_at: DateTime
-      ending_srs_stage: uint // 1..9
+      ending_srs_stage: ReviewEndingSrsStage
       incorrect_meaning_answers: uint
       incorrect_reading_answers: uint
       spaced_repetition_system_id: uint
-      starting_srs_stage: uint // 1..8
+      starting_srs_stage: ReviewStartingSrsStage
       subject_id: uint }
 
 type ReviewStatistics =


### PR DESCRIPTION
Update dependencies and dev tools

Refactor UserOverview as MainView to reflect the new elmish app division. The main view will be the parent to all views of a logged in user. UserOverview would be a child app.

Add link to user profile to the side  bar.

Fix sidebar getting onclick event from main content.

Fix main view events popping up after logout.

Improve the login view visuals. Add the app title and fix the aligning issues between the input and button. Add quality of life improvements to input field like watermark, onEnterDown event, bigger font, and token length validation, etc.

Add user progress indicator boxes to the main view. The boxes represent the learning stages of kanji and show a counter how many kanjis currently are on that level. Also, use enums to represent the user progress in data to give some domain terms the the plain numbers.